### PR TITLE
refs #5 apollo clientを導入して、graphQLのqueryを実行する

### DIFF
--- a/react_app/package-lock.json
+++ b/react_app/package-lock.json
@@ -934,8 +934,7 @@
     "@types/node": {
       "version": "12.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.2.tgz",
-      "integrity": "sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==",
-      "dev": true
+      "integrity": "sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ=="
     },
     "@types/prop-types": {
       "version": "15.7.1",
@@ -977,6 +976,11 @@
         "@types/react": "*",
         "@types/react-router": "*"
       }
+    },
+    "@types/zen-observable": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -1154,6 +1158,23 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/context": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
+      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "requires": {
+        "@types/node": ">=6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
+      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -1252,6 +1273,94 @@
             "remove-trailing-separator": "^1.0.1"
           }
         }
+      }
+    },
+    "apollo-cache": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.2.tgz",
+      "integrity": "sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==",
+      "requires": {
+        "apollo-utilities": "^1.3.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-cache-inmemory": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.2.tgz",
+      "integrity": "sha512-AyCl3PGFv5Qv1w4N9vlg63GBPHXgMCekZy5mhlS042ji0GW84uTySX+r3F61ZX3+KM1vA4m9hQyctrEGiv5XjQ==",
+      "requires": {
+        "apollo-cache": "^1.3.2",
+        "apollo-utilities": "^1.3.2",
+        "optimism": "^0.9.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-client": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.3.tgz",
+      "integrity": "sha512-DS8pmF5CGiiJ658dG+mDn8pmCMMQIljKJSTeMNHnFuDLV0uAPZoeaAwVFiAmB408Ujqt92oIZ/8yJJAwSIhd4A==",
+      "requires": {
+        "@types/zen-observable": "^0.8.0",
+        "apollo-cache": "1.3.2",
+        "apollo-link": "^1.0.0",
+        "apollo-utilities": "1.3.2",
+        "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz",
+      "integrity": "sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==",
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.19"
+      }
+    },
+    "apollo-link-error": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.11.tgz",
+      "integrity": "sha512-442DNqn3CNRikDaenMMkoDmCRmkoUx/XyUMlRTZBEFdTw3FYPQLsmDO3hzzC4doY5/BHcn9/jdYh9EeLx4HPsA==",
+      "requires": {
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-link-http": {
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.15.tgz",
+      "integrity": "sha512-epZFhCKDjD7+oNTVK3P39pqWGn4LEhShAoA1Q9e2tDrBjItNfviiE33RmcLcCURDYyW5JA6SMgdODNI4Is8tvQ==",
+      "requires": {
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-link-http-common": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz",
+      "integrity": "sha512-v6mRU1oN6XuX8beVIRB6OpF4q1ULhSnmy7ScnHnuo1qV6GaFmDcbdvXqxIkAV1Q8SQCo2lsv4HeqJOWhFfApOg==",
+      "requires": {
+        "apollo-link": "^1.2.12",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+      "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "aproba": {
@@ -2674,8 +2783,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -3522,6 +3630,19 @@
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
+    "graphql": {
+      "version": "14.4.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz",
+      "integrity": "sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-tag": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
+      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
+    },
     "gud": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
@@ -4016,6 +4137,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "iterall": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -4113,6 +4239,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "loglevel": {
       "version": "1.6.3",
@@ -4644,6 +4775,14 @@
         "is-wsl": "^1.1.0"
       }
     },
+    "optimism": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.9.6.tgz",
+      "integrity": "sha512-bWr/ZP32UgFCQAoSkz33XctHwpq2via2sBvGvO5JIlrU8gaiM0LvoKj3QMle9LWdSKlzKik8XGSerzsdfYLNxA==",
+      "requires": {
+        "@wry/context": "^0.4.0"
+      }
+    },
     "original": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -5071,6 +5210,20 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
+      }
+    },
+    "react-apollo": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.5.8.tgz",
+      "integrity": "sha512-60yOQrnNosxU/tRbOxGDaYNLFcOKmQqxHPhxyvKTlGIaF/rRCXQRKixUgWVffpEupSHHD7psY5k5ZOuZsdsSGQ==",
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash.isequal": "^4.5.0",
+        "prop-types": "^15.7.2",
+        "ts-invariant": "^0.4.2",
+        "tslib": "^1.9.3"
       }
     },
     "react-dom": {
@@ -6026,6 +6179,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -6178,6 +6336,14 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "ts-loader": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.0.4.tgz",
@@ -6245,8 +6411,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -6920,6 +7085,20 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "zen-observable": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
+      "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/react_app/package.json
+++ b/react_app/package.json
@@ -33,7 +33,14 @@
     "@types/react": "^16.8.23",
     "@types/react-dom": "^16.8.4",
     "@types/react-router-dom": "^4.3.4",
+    "apollo-cache-inmemory": "^1.6.2",
+    "apollo-client": "^2.6.3",
+    "apollo-link-error": "^1.1.11",
+    "apollo-link-http": "^1.5.15",
+    "graphql": "^14.4.2",
+    "graphql-tag": "^2.10.1",
     "react": "^16.8.6",
+    "react-apollo": "^2.5.8",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.1"
   }

--- a/react_app/src/apolloClient.tsx
+++ b/react_app/src/apolloClient.tsx
@@ -1,0 +1,30 @@
+import { ApolloClient } from 'apollo-client';
+import { HttpLink } from 'apollo-link-http';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { onError } from 'apollo-link-error'
+import { ApolloLink } from 'apollo-link'
+
+const httpLink = new HttpLink({
+  uri: 'https://api.github.com/graphql',
+  headers: {
+    authorization: `Bearer ${githubのtokenがはいるよ}`
+  }
+});
+
+const errorLink = onError(({ graphQLErrors, networkError }) => {
+  if (graphQLErrors) {
+    // do something with graphql error
+  }
+
+  if (networkError) {
+    // do something with network error
+  }
+});
+
+const link = ApolloLink.from([errorLink, httpLink]);
+const cache = new InMemoryCache();
+
+export const client = new ApolloClient({
+  link,
+  cache
+});

--- a/react_app/src/components/GithubPage.tsx
+++ b/react_app/src/components/GithubPage.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import gql from 'graphql-tag';
+import { Query } from 'react-apollo';
+
+const query = gql`
+  {
+    organization(login: "apollographql") {
+      repositories(first: 5, isFork: false) {
+        nodes {
+          id
+          name
+          url
+          viewerHasStarred
+          stargazers {
+            totalCount
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const GithubPage = () => (
+  <Query query={query}>
+    {({ loading, data }: any) => {
+      if (loading) return <p>Loading...</p>;
+
+      const repositories = data.organization.repositories.nodes;
+
+      return (
+        <ul>
+          {repositories.map((repo: any) => (
+            <li key={repo.id}>
+              <a href={repo.url}>{repo.name}</a>
+              <button>{repo.stargazers.totalCount} Star</button>
+            </li>
+          ))}
+        </ul>
+      );
+    }}
+  </Query>
+);

--- a/react_app/src/components/Page1.tsx
+++ b/react_app/src/components/Page1.tsx
@@ -1,7 +1,0 @@
-import * as React from "react";
-
-export class Page1 extends React.Component {
-  render() {
-    return <h1>ルーティングされた!</h1>;
-  }
-}

--- a/react_app/src/index.tsx
+++ b/react_app/src/index.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { ApolloProvider } from 'react-apollo';
+import { client } from './apolloClient'
 import { Routes } from './routes'
 import './favicon.ico';
 
 ReactDOM.render(
-  <Routes />,
+  <ApolloProvider client={client}>
+    <Routes />
+  </ApolloProvider>,
   document.getElementById('app')
 );

--- a/react_app/src/routes.tsx
+++ b/react_app/src/routes.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { BrowserRouter, Switch, Route, Link } from 'react-router-dom'
 
 import { App } from './components/App';
-import { Page1 } from './components/Page1'
+import { GithubPage } from './components/GithubPage'
 import { NotFound } from './components/NotFound'
 
 export const Routes = () => (
@@ -10,13 +10,13 @@ export const Routes = () => (
     <div>
       <ul>
         <li><Link to='/'>Home</Link></li>
-        <li><Link to='/page1'>Page1</Link></li>
+        <li><Link to='/github_page'>GithubPage</Link></li>
       </ul>
 
       <hr />
       <Switch>
         <Route exact path='/' component={App} />
-        <Route path='/page1' component={Page1} />
+        <Route path='/github_page' component={GithubPage} />
         <Route component={NotFound} />
       </Switch>
     </div>


### PR DESCRIPTION
## 導入の前に

reactでgraph-qlを使おうとすると大抵はapolloを使用するが  
大きく分けて２パターンある  

1. apollo-clientならびに関連パッケージを入れていく
1. apollo-boostを使う

後者は関連パッケージのインストールと一部の設定を自動でやってくれる  
ツールであるが、細かな設定ができないため後からいろいろしようとすると  
自由度が聞かないことがあるらしい、そのため前者の導入を進めた

## 導入に関して

参考としたサイトは公式およびQiita記事とか  
公式(apollo-client)：https://github.com/apollographql/apollo-client  
Qiita：https://qiita.com/seya/items/e1d8e77352239c4c4897  

ただし、このリポジトリの環境だとtypescriptを使用していることもあり、  
それだけだと型定義で怒られるので@typesのnpm installもしている  

ある程度エラーを見つつ場当たり的に動いたので、  
詳しい内容はpackage.jsonを確認してもらうのが良い  

注意事項としては@types以外にもapollo-link-errorなどいくつか  
参考記事では使っているがインストールが省略されているものがある（boostでやっているから？）  
なので注意すること  

他にも、githubへのtokenの設定が必要なのでリポジトリをそのまま引いてくるときは注意