### PR TITLE
refs #7 material-uiを入れて試してみる

### DIFF
--- a/react_app/package-lock.json
+++ b/react_app/package-lock.json
@@ -903,6 +903,111 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/hash": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.2.tgz",
+      "integrity": "sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q=="
+    },
+    "@material-ui/core": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.2.1.tgz",
+      "integrity": "sha512-hasPQUFAb9OxKng7UX2+SjUWtVZbnkVJ/jHZWXTivVcU+UzvNIpA9AyRRQvZ8SPV6swP/HD2VzUBzoMEeRR6wg==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "@material-ui/styles": "^4.2.0",
+        "@material-ui/system": "^4.3.0",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.1.0",
+        "@types/react-transition-group": "^2.0.16",
+        "clsx": "^1.0.2",
+        "convert-css-length": "^2.0.1",
+        "deepmerge": "^4.0.0",
+        "hoist-non-react-statics": "^3.2.1",
+        "is-plain-object": "^3.0.0",
+        "normalize-scroll-left": "^0.2.0",
+        "popper.js": "^1.14.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.0.0",
+        "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        }
+      }
+    },
+    "@material-ui/icons": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.2.1.tgz",
+      "integrity": "sha512-FvSD5lUBJ66frI4l4AYAPy2CH14Zs2Dgm0o3oOMr33BdQtOAjCgbdOcvPBeaD1w6OQl31uNW3CKOE8xfPNxvUQ==",
+      "requires": {
+        "@babel/runtime": "^7.2.0"
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.2.1.tgz",
+      "integrity": "sha512-1KSOZ17LBWBqIyPRsEpyb4snT/wRIfQTPi0x66UvSzznVK9MPAfJx3/s5lVT4vrGFObs/nj6Pet6Nhrdl2WCrg==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "@emotion/hash": "^0.7.1",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.1.0",
+        "clsx": "^1.0.2",
+        "csstype": "^2.5.2",
+        "deepmerge": "^4.0.0",
+        "hoist-non-react-statics": "^3.2.1",
+        "jss": "10.0.0-alpha.17",
+        "jss-plugin-camel-case": "10.0.0-alpha.17",
+        "jss-plugin-default-unit": "10.0.0-alpha.17",
+        "jss-plugin-global": "10.0.0-alpha.17",
+        "jss-plugin-nested": "10.0.0-alpha.17",
+        "jss-plugin-props-sort": "10.0.0-alpha.17",
+        "jss-plugin-rule-value-function": "10.0.0-alpha.17",
+        "jss-plugin-vendor-prefixer": "10.0.0-alpha.17",
+        "prop-types": "^15.7.2",
+        "warning": "^4.0.1"
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.3.1.tgz",
+      "integrity": "sha512-Krrc/p/A3rod4M3FYcsWSqE5KxpoyMzYuUHhs0Pns3KH+5kcFyBU+aYbIzMfUz58rhbHkqrShf1fjj7EKcgY0g==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "deepmerge": "^4.0.0",
+        "prop-types": "^15.7.2",
+        "warning": "^4.0.1"
+      }
+    },
+    "@material-ui/types": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
+      "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@material-ui/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -975,6 +1080,14 @@
         "@types/history": "*",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.9.2.tgz",
+      "integrity": "sha512-5Fv2DQNO+GpdPZcxp2x/OQG/H19A01WlmpjVD9cKvVFmoVLOZ9LvBgSWG6pSXIU4og5fgbvGPaCV5+VGkWAEHA==",
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/zen-observable": {
@@ -1954,6 +2067,11 @@
         "wrap-ansi": "^5.1.0"
       }
     },
+    "clsx": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
+      "integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg=="
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -2080,6 +2198,11 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
+    },
+    "convert-css-length": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.1.tgz",
+      "integrity": "sha512-iGpbcvhLPRKUbBc0Quxx7w/bV14AC3ItuBEGMahA5WTYqB8lq9jH0kTXFheCBASsYnqeMFZhiTruNxr1N59Axg=="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -2222,6 +2345,15 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css-vendor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.5.tgz",
+      "integrity": "sha512-36w+4Cg0zqFIt5TAkaM3proB6XWh5kSGmbddRCPdrRLQiYNfHPTgaWPOlCrcuZIO0iAtrG+5wsHJZ6jj8AUULA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "is-in-browser": "^1.0.2"
+      }
+    },
     "csstype": {
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
@@ -2265,6 +2397,11 @@
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+      "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -2409,6 +2546,14 @@
       "dev": true,
       "requires": {
         "buffer-indexof": "^1.0.0"
+      }
+    },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
       }
     },
     "domain-browser": {
@@ -3839,6 +3984,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "hyphenate-style-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4048,6 +4198,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -4184,6 +4339,82 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jss": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-aPY4kr6MwliH7KToLRzeSk1NxXUo9n7MQsAa0Hghwj01x9UnMkDkGAKENMKUtPjGkQZfiJpB9tTLFrSJ/6VrIQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.0.0-alpha.17"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-KQgiXczvzJ9AlFdD8NS7FZLub0NSctSrCA9Yi/GqdsfJg4ZCriU4DzIybCZBHCi/INFGJmLIESYWSxnuhAzgSQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-WYxiwwI+CLk0ozW8loeceqXBAZXBMsLBEZeRwVf9WX+FljdJkGwVZpRCk6LBX4aXnqAGyKqCxIAIJ3KP2yBdEg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-onpFqv904KCujryf2t6IIV1/QoB7cSF7ojrd4UujcN5TPvYOvXF5bchi7jnHG5U0SLlRSDGMLJ9fhtoCknhEbw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-KnbyrxCbtQTqpDx2mSZU/r/E5QnDPIVfIxRi8K+W/q4gZpomBvqWC+xgvAk9hbpmA6QBoQaOilV8o12w2IZ6fg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-8AuJB44Q+ehfkWVRi2XlRbUf6SrLmrHTa5EXd6dgQRCCRuvGmqX8Dl4fZvNeKRFjTLPZgzg9+31rqeOMhKa2vA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-wDq9EL0QaoMGSGifPEBb+/SA9LBcqPEW0jpL9ht+Z2t+lV7NNz0j7uCEOuE6FvNWqHzUKTsiATs1rTHPkzNBEQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.1",
+        "jss": "10.0.0-alpha.17"
       }
     },
     "killable": {
@@ -4649,6 +4880,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-scroll-left": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
+      "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -5012,6 +5248,11 @@
         "find-up": "^3.0.0"
       }
     },
+    "popper.js": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+    },
     "portfinder": {
       "version": "1.0.21",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
@@ -5286,6 +5527,17 @@
         "react-router": "5.0.1",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-transition-group": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.1.tgz",
+      "integrity": "sha512-IXrPr93VzCPupwm2O6n6C2kJIofJ/Rp5Ltihhm9UfE8lkuVX2ng/SUUl/oWjblybK9Fq2Io7LGa6maVqPB762Q==",
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
       }
     },
     "readable-stream": {
@@ -6657,6 +6909,14 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
       "dev": true
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "watchpack": {
       "version": "1.6.0",

--- a/react_app/package.json
+++ b/react_app/package.json
@@ -30,6 +30,8 @@
     "webpack-dev-server": "^3.7.2"
   },
   "dependencies": {
+    "@material-ui/core": "^4.2.1",
+    "@material-ui/icons": "^4.2.1",
     "@types/react": "^16.8.23",
     "@types/react-dom": "^16.8.4",
     "@types/react-router-dom": "^4.3.4",

--- a/react_app/src/components/User.tsx
+++ b/react_app/src/components/User.tsx
@@ -1,6 +1,12 @@
+// react
 import * as React from 'react';
+
+// graphQL
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
+
+// material-ui
+import CircularProgress from '@material-ui/core/CircularProgress'
 
 const query = gql`
   {
@@ -18,7 +24,7 @@ const query = gql`
 export const User = () => (
   <Query query={query}>
     {({ loading, data }: any) => {
-      if (loading) return <p>Loading...</p>;
+      if (loading) return <CircularProgress className='loading' />;
 
       const user = data.user;
       const tags = data.user.tags;

--- a/react_app/src/components/WithoutAppBarPage.tsx
+++ b/react_app/src/components/WithoutAppBarPage.tsx
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+export class WithoutAppBarPage extends React.Component {
+  render() {
+    return <h1>このページはapp Barに含まれません</h1>;
+  }
+}

--- a/react_app/src/index.tsx
+++ b/react_app/src/index.tsx
@@ -1,8 +1,13 @@
+// react
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+
+// apollo
 import { ApolloProvider } from 'react-apollo';
 import { client } from './apolloClient'
 import { Routes } from './routes'
+
+// favicon 設定はindex.htmlで行なっている
 import './favicon.ico';
 
 ReactDOM.render(

--- a/react_app/src/routes.tsx
+++ b/react_app/src/routes.tsx
@@ -1,24 +1,72 @@
+// react
 import * as React from 'react';
 import { BrowserRouter, Switch, Route, Link } from 'react-router-dom'
 
+// components for links
 import { App } from './components/App';
 import { User } from './components/User'
+import { WithoutAppBarPage } from './components/WithoutAppBarPage'
 import { NotFound } from './components/NotFound'
 
-export const Routes = () => (
-  <BrowserRouter>
-    <div>
-      <ul>
-        <li><Link to='/'>Home</Link></li>
-        <li><Link to='/user'>User</Link></li>
-      </ul>
+// @material-ui
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+import MenuIcon from '@material-ui/icons/Menu';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import Paper from '@material-ui/core/Paper';
+
+export function Routes() {
+
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function handleClose() {
+    setAnchorEl(null);
+  }
+  
+  return (
+    <BrowserRouter>
+      <div className='menu'>
+        <AppBar position="static">
+          <Toolbar variant="dense">
+            <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick}>
+              <MenuIcon />
+            </Button>
+            <Menu
+              id="simple-menu"
+              anchorEl={anchorEl}
+              keepMounted
+              open={Boolean(anchorEl)}
+              onClose={handleClose}
+            >
+              <MenuItem onClick={handleClose}><Link to='/'>Home</Link></MenuItem>
+              <MenuItem onClick={handleClose}><Link to='/user'>User</Link></MenuItem>
+            </Menu>
+            <Typography variant="h6" color="inherit">
+              MyGraphQL
+            </Typography>
+          </Toolbar>
+        </AppBar>
+      </div>
 
       <hr />
-      <Switch>
-        <Route exact path='/' component={App} />
-        <Route path='/user' component={User} />
-        <Route component={NotFound} />
-      </Switch>
-    </div>
-  </BrowserRouter>
-)
+      
+      <div>
+        <Paper className='paper' style={{backgroundColor: '#ffffe0'}}>
+          <Switch>
+            <Route exact path='/' component={App} />
+            <Route path='/user' component={User} />
+            <Route path='/without_app_bar_page' component={WithoutAppBarPage} />
+            <Route component={NotFound} />
+          </Switch>
+        </Paper>
+      </div>
+    </BrowserRouter>
+  );
+}


### PR DESCRIPTION
## material-uiの導入

coreとiconをnpm installした
  
あとはコンポーネントに必要な処理を書き加えてみた程度

## loading画面

graphqlではloadingの時のstateが明確に存在するため、  
その時にloadingのアイコンが出るようにした  
ぶっちゃけ一瞬でできる  

## appBar
サービスのトップにBarを表示する（githubの上の黒い部分みたいなやつ）  
コードの実装的にもともと作っていたroutesファイルの中の記載になる  
appBarの中はサービス内の大項目へのリンクとなりやすいので、  
下手に分けると２重管理になる。次回にこれの解消を考える  

## paper

なんとなく、各ページのコンテンツをpaperで囲んでみた  
特に深い意味はない  
こちらも全ページでそれをやるためroutesのファイルへの  
追記となるが処理が、他の処理と疎結合のためそんなに
構成が汚くならない